### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/1.17-modd.yml
+++ b/.github/workflows/1.17-modd.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
       - 
         name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: bigrocs/golang-gcc-modd
           dockerfile: ./1.17-modd/Dockerfile

--- a/.github/workflows/1.18-alpine.yml
+++ b/.github/workflows/1.18-alpine.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
       - 
         name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: bigrocs/golang-gcc
           dockerfile: ./1.18-alpine/Dockerfile

--- a/.github/workflows/1.18-modd.yml
+++ b/.github/workflows/1.18-modd.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
       - 
         name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: bigrocs/golang-gcc-modd
           dockerfile: ./1.18-modd/Dockerfile

--- a/.github/workflows/1.19-alpine.yml
+++ b/.github/workflows/1.19-alpine.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
       - 
         name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: bigrocs/golang-gcc
           dockerfile: ./1.19-alpine/Dockerfile

--- a/.github/workflows/1.19-modd.yml
+++ b/.github/workflows/1.19-modd.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
       - 
         name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: bigrocs/golang-gcc-modd
           dockerfile: ./1.19-modd/Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       run: git fetch --prune --unshallow
 
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: bigrocs/golang-gcc
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore